### PR TITLE
enable cpp target

### DIFF
--- a/src/demo/Main.hx
+++ b/src/demo/Main.hx
@@ -54,6 +54,10 @@ class Main
     php.Lib.print(template.execute(h));
 #elseif neko
     neko.Lib.print(template.execute(h));
+#elseif cpp
+    cpp.Lib.print(template.execute(h));
+#else
+	trace(template.execute(h));
 #end
   }
 }

--- a/src/erazor/Parser.hx
+++ b/src/erazor/Parser.hx
@@ -94,8 +94,8 @@ class Parser
 	
 	function accept(template : String, acceptor : String -> Bool, throwAtEnd : Bool)
 	{
-		return parseString(template, function(char : String) {
-			return acceptor(char) ? ParseResult.keepGoing : ParseResult.doneSkipCurrent;
+		return parseString(template, function(chr : String) {
+			return acceptor(chr) ? ParseResult.keepGoing : ParseResult.doneSkipCurrent;
 		}, throwAtEnd);
 	}
 	
@@ -111,8 +111,8 @@ class Parser
 		var first = true;
 		var self = this;
 		
-		return accept(template, function(char : String) {
-			var status = self.isIdentifier(char, first);
+		return accept(template, function(chr : String) {
+			var status = self.isIdentifier(chr, first);
 			first = false;
 			return status;
 		}, false);

--- a/src/haxelib.xml
+++ b/src/haxelib.xml
@@ -2,6 +2,7 @@
     <user name="fponticelli"/>
 	<tag v="cross"/>
 	<tag v="template" />
+    <depends name="hscript" version="1.6"/>
     <description>A haXe implementation of the MVC 3 Razor view engine</description>
     <version name="0.1.0">First Release</version>
 </project>


### PR DESCRIPTION
Workaround a cpp bug.
Added `<depends name="hscript" version="1.6"/>` to haxelib.xml.

Note that one case in the unittest fails, which I'm not sure what's wrong:

```
PrintReport.hx:66: results: SOME TESTS FAILURES

assertations: 44
successes: 43
errors: 0
failures: 1
warnings: 0
execution time: 0.003

erazor.TestTemplate
  test_If_keyword_vars_are_parsed_correctly: FAILURE ...F
    line: 46, expected "987654321" but was "45"
```
