### PR TITLE
Keep Output#unsafeAdd such that it works in dce full.

### DIFF
--- a/src/erazor/Output.hx
+++ b/src/erazor/Output.hx
@@ -48,7 +48,7 @@ class Output extends StringBuf {
 		return str;
 	}
 
-	public inline function unsafeAdd( str : Dynamic ){
+	@:keep public inline function unsafeAdd( str : Dynamic ){
 		var val = if( Std.is( str , TString ) ){
 			str.toString();
 		}else{


### PR DESCRIPTION
This fixed the issue of using `-dce full`, erazor will fail with the simplest template:

```
import erazor.Template;
class Test {
    static function main():Void {
        trace(new Template("@abc").execute({abc:"ABC"}));
    }
}
```
